### PR TITLE
Add LockMiddleware

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -39,5 +39,9 @@ return (new PhpCsFixer\Config())
         'multiline_whitespace_before_semicolons' => true,
         'single_line_throw' => false,
         'visibility_required' => ['elements' => ['property', 'method', 'const']],
+        'phpdoc_to_comment' => [
+            'ignored_tags' => ['todo', 'var', 'see'],
+        ],
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
     ])
     ->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ This way we make sure that the real exception is thrown out by this message
 bus, and a controller can catch or convert it to a specific http status code.
 This middleware is always activated in the sulu message bus.
 
+### LockMiddleware
+
+The `LockMiddleware` will allow to lock specific resources by a given key. This is commonly
+used to prevent concurrent access to the same resource and avoid race conditions.
+The locking can be activated and controlled via the `LockStamp` which supports the same parameters
+as the Symfony `LockFactory` to create the Lock.
+
+```php
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockStamp;
+
+$this->handle(new Envelope(new YourMessage(), [new LockStamp('lock-key')]));
+
+# set ttl and autorelease
+$this->handle(new Envelope(new YourMessage(), [new LockStamp('lock-key', 300.0, true)]));
+
+# multiple locks possible all locks need to be acquired before processing the message
+$this->handle(new Envelope(new YourMessage(), [new LockStamp('lock-key-1'), new LockStamp('lock-key-2')]));
+```
+
 ### DoctrineFlushMiddleware
 
 The `DoctrineFlushMiddleware` is a Middleware which let us flush the Doctrine

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "symfony/doctrine-bridge": "^5.4 || ^6.0",
         "symfony/framework-bundle": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/lock": "^5.4 || ^6.0",
         "symfony/messenger": "^5.4 || ^6.0"
     },
     "require-dev": {
@@ -22,6 +23,7 @@
         "jangregor/phpstan-prophecy": "^1.0",
         "nunomaduro/collision": "^5.0 || ^6.0",
         "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-doctrine": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
@@ -29,16 +31,16 @@
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^9.5",
         "qossmic/deptrac-shim": "^0.19.3",
-        "rector/rector": "^0.12.16",
-        "schranz/test-generator": "^0.3",
+        "rector/rector": "^0.13.10",
+        "schranz/test-generator": "^0.4",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/css-selector": "^5.4 || ^6.0",
         "symfony/debug-bundle": "^5.4 || ^6.0",
+        "symfony/dotenv": "^5.4 || ^6.0",
         "symfony/error-handler": "^5.4 || ^6.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.0",
-        "thecodingmachine/phpstan-strict-rules": "^1.0",
-        "symfony/dotenv": "^5.4 || ^6.0",
-        "symfony/yaml": "^5.4 || ^6.0"
+        "symfony/yaml": "^5.4 || ^6.0",
+        "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -100,6 +102,9 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,10 @@
         "rector": [
             "@php vendor/bin/rector process"
         ],
+        "fix": [
+            "@rector",
+            "@php-cs-fix"
+        ],
         "php-cs": "@php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "php-cs-fix": "@php vendor/bin/php-cs-fixer fix",
         "lint-composer": "@composer validate --no-check-publish --strict",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan-symfony": "^1.1",
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "qossmic/deptrac-shim": "^0.19.3",
+        "qossmic/deptrac-shim": "^0.23.0",
         "rector/rector": "^0.13.10",
         "schranz/test-generator": "^0.4",
         "symfony/browser-kit": "^5.4 || ^6.0",

--- a/config/services.php
+++ b/config/services.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\DoctrineFlushMiddleware;
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockMiddleware;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\UnpackExceptionMiddleware\UnpackExceptionMiddleware;
 
 return function (ContainerConfigurator $configurator) {
@@ -16,4 +17,8 @@ return function (ContainerConfigurator $configurator) {
 
     $services->set('sulu_messenger.unpack_exception_middleware')
         ->class(UnpackExceptionMiddleware::class);
+
+    $services->set('sulu_messenger.lock_middleware')
+        ->class(LockMiddleware::class)
+        ->args([service('lock.factory')]);
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,3 @@
-includes:
-    - vendor/jangregor/phpstan-prophecy/extension.neon
-    - vendor/phpstan/phpstan-symfony/extension.neon
-    - vendor/phpstan/phpstan-doctrine/extension.neon
-    - vendor/phpstan/phpstan-doctrine/rules.neon
-    - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-phpunit/rules.neon
-    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
-    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
-
 parameters:
     paths:
         - src

--- a/rector.php
+++ b/rector.php
@@ -30,7 +30,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->sets([
         SetList::CODE_QUALITY,
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_80,
     ]);
 
     // symfony rules

--- a/rector.php
+++ b/rector.php
@@ -2,42 +2,54 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
+use Rector\Config\RectorConfig;
 use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\Symfony\Set\SymfonyLevelSetList;
 use Rector\Symfony\Set\SymfonySetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
-    $services = $containerConfigurator->services();
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
 
-    $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/tests']);
-    $parameters->set(Option::SKIP, [
+    $rectorConfig->skip([
         __DIR__ . '/tests/Application/var',
         __DIR__ . '/tests/Application/config',
     ]);
-    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan.neon');
+
+    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
 
     // basic rules
-    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
-    $parameters->set(Option::IMPORT_DOC_BLOCKS, true);
-    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses();
 
-    $containerConfigurator->import(SetList::CODE_QUALITY);
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_80);
+    $rectorConfig->sets([
+        SetList::CODE_QUALITY,
+        LevelSetList::UP_TO_PHP_81,
+    ]);
 
     // symfony rules
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(
-        Option::SYMFONY_CONTAINER_XML_PATH_PARAMETER,
-        __DIR__ . '/tests/Application/var/cache/dev/Sulu_Messenger_Tests_Application_KernelDevDebugContainer.xml'
-    );
-    $containerConfigurator->import(SymfonySetList::SYMFONY_CODE_QUALITY);
-    $containerConfigurator->import(SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION);
-    $containerConfigurator->import(SymfonyLevelSetList::UP_TO_SYMFONY_54);
+    $rectorConfig->symfonyContainerPhp(__DIR__ . '/tests/Application/var/cache/dev/Sulu_Messenger_Tests_Application_KernelDevDebugContainer.xml');
 
-    $containerConfigurator->import(DoctrineSetList::DOCTRINE_CODE_QUALITY);
+    $rectorConfig->sets([
+        SymfonySetList::SYMFONY_CODE_QUALITY,
+        SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
+        SymfonyLevelSetList::UP_TO_SYMFONY_54,
+    ]);
+
+    // doctrine rules
+    $rectorConfig->sets([
+        DoctrineSetList::DOCTRINE_CODE_QUALITY,
+    ]);
+
+    // phpunit rules
+    $rectorConfig->sets([
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_91,
+    ]);
 };

--- a/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SuluMessengerBundle extends Bundle implements ExtensionInterface, PrependExtensionInterface, ConfigurationExtensionInterface, ConfigurationInterface
 {
-    final public const ALIAS = 'sulu_messenger';
+    public const ALIAS = 'sulu_messenger';
 
     public function getPath(): string
     {

--- a/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sulu\Messenger\Infrastructure\Symfony\HttpKernel;
 
+use RuntimeException;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
@@ -19,7 +20,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SuluMessengerBundle extends Bundle implements ExtensionInterface, PrependExtensionInterface, ConfigurationExtensionInterface, ConfigurationInterface
 {
-    public const ALIAS = 'sulu_messenger';
+    final public const ALIAS = 'sulu_messenger';
 
     public function getPath(): string
     {
@@ -52,7 +53,7 @@ class SuluMessengerBundle extends Bundle implements ExtensionInterface, PrependE
     public function prepend(ContainerBuilder $container): void
     {
         if (!$container->hasExtension('framework')) {
-            throw new \RuntimeException(\sprintf('The "%s" bundle requires "framework" bundle.', self::ALIAS));
+            throw new RuntimeException(\sprintf('The "%s" bundle requires "framework" bundle.', self::ALIAS));
         }
 
         $container->prependExtensionConfig(

--- a/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
@@ -70,7 +70,7 @@ class SuluMessengerBundle extends Bundle implements ExtensionInterface, PrependE
                         ],
                     ],
                 ],
-            ]
+            ],
         );
     }
 

--- a/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluMessengerBundle.php
@@ -64,6 +64,7 @@ class SuluMessengerBundle extends Bundle implements ExtensionInterface, PrependE
                         'sulu_message_bus' => [
                             'middleware' => [
                                 'sulu_messenger.unpack_exception_middleware',
+                                'sulu_messenger.lock_middleware',
                                 'sulu_messenger.doctrine_flush_middleware',
                             ],
                         ],

--- a/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 class DoctrineFlushMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private EntityManagerInterface $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 class DoctrineFlushMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
+        private EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 class DoctrineFlushMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private EntityManagerInterface $entityManager
+        private EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 class LockMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private LockFactory $lockFactory,
+        private readonly LockFactory $lockFactory,
     ) {
     }
 

--- a/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 class LockMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly LockFactory $lockFactory,
+        private LockFactory $lockFactory,
     ) {
     }
 

--- a/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware;
+
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+class LockMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private LockFactory $lockFactory
+    ) {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $locks = [];
+
+        try {
+            /** @var LockStamp[] $lockStamps */
+            $lockStamps = $envelope->all(LockStamp::class);
+
+            foreach ($lockStamps as $lockStamp) {
+                $lock = $this->lockFactory->createLock(
+                    $lockStamp->getResource(),
+                    $lockStamp->getTtl(),
+                    $lockStamp->getAutoRelease(),
+                );
+
+                $lock->acquire(true);
+                $locks[] = $lock;
+            }
+
+            $envelope = $stack->next()->handle($envelope, $stack);
+        } finally {
+            foreach ($locks as $lock) {
+                $lock->release();
+            }
+        }
+
+        return $envelope;
+    }
+}

--- a/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddleware.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
 class LockMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private LockFactory $lockFactory
+        private LockFactory $lockFactory,
     ) {
     }
 

--- a/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockStamp.php
+++ b/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockStamp.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Stamp to lock a process handling to avoid race conditions.
+ */
+class LockStamp implements StampInterface
+{
+    public function __construct(
+        private string $resource,
+        private ?float $ttl = 300.0,
+        private bool $autoRelease = true,
+    ) {
+    }
+
+    public function getResource(): string
+    {
+        return $this->resource;
+    }
+
+    public function getTtl(): ?float
+    {
+        return $this->ttl;
+    }
+
+    public function getAutoRelease(): bool
+    {
+        return $this->autoRelease;
+    }
+}

--- a/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockStamp.php
+++ b/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockStamp.php
@@ -12,9 +12,9 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 class LockStamp implements StampInterface
 {
     public function __construct(
-        private string $resource,
-        private ?float $ttl = 300.0,
-        private bool $autoRelease = true,
+        private readonly string $resource,
+        private readonly ?float $ttl = 300.0,
+        private readonly bool $autoRelease = true,
     ) {
     }
 

--- a/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockStamp.php
+++ b/src/Infrastructure/Symfony/Messenger/LockMiddleware/LockStamp.php
@@ -12,9 +12,9 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 class LockStamp implements StampInterface
 {
     public function __construct(
-        private readonly string $resource,
-        private readonly ?float $ttl = 300.0,
-        private readonly bool $autoRelease = true,
+        private string $resource,
+        private ?float $ttl = 300.0,
+        private bool $autoRelease = true,
     ) {
     }
 

--- a/tests/Traits/PrivatePropertyTrait.php
+++ b/tests/Traits/PrivatePropertyTrait.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Sulu\Messenger\Tests\Traits;
 
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+
 trait PrivatePropertyTrait
 {
     /**
@@ -11,23 +15,20 @@ trait PrivatePropertyTrait
      */
     protected static function getPrivateProperty(object $object, string $propertyName)
     {
-        $reflection = new \ReflectionClass($object);
+        $reflection = new ReflectionClass($object);
         $propertyReflection = $reflection->getProperty($propertyName);
         $propertyReflection->setAccessible(true);
 
         return $propertyReflection->getValue($object);
     }
 
-    /**
-     * @param mixed $value
-     */
-    protected static function setPrivateProperty(object $object, string $propertyName, $value): void
+    protected static function setPrivateProperty(object $object, string $propertyName, mixed $value): void
     {
-        $reflection = new \ReflectionClass($object);
+        $reflection = new ReflectionClass($object);
         try {
             $propertyReflection = $reflection->getProperty($propertyName);
             self::setValue($propertyReflection, $object, $value);
-        } catch (\ReflectionException) {
+        } catch (ReflectionException) {
             $parent = $reflection->getParentClass();
             if ($parent) {
                 $propertyReflection = $parent->getProperty($propertyName);
@@ -36,7 +37,7 @@ trait PrivatePropertyTrait
         }
     }
 
-    private static function setValue(\ReflectionProperty $propertyReflection, object $object, mixed $value): void
+    private static function setValue(ReflectionProperty $propertyReflection, object $object, mixed $value): void
     {
         $propertyReflection->setAccessible(true);
 

--- a/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
@@ -31,7 +31,7 @@ class DoctrineFlushMiddlewareTest extends TestCase
     {
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
         $this->middleware = new DoctrineFlushMiddleware(
-            $this->entityManager->reveal()
+            $this->entityManager->reveal(),
         );
     }
 
@@ -45,7 +45,7 @@ class DoctrineFlushMiddlewareTest extends TestCase
 
         $this->assertSame(
             $envelope,
-            $this->middleware->handle($envelope, $stack)
+            $this->middleware->handle($envelope, $stack),
         );
     }
 
@@ -60,7 +60,7 @@ class DoctrineFlushMiddlewareTest extends TestCase
 
         $this->assertSame(
             $envelope,
-            $this->middleware->handle($envelope, $stack)
+            $this->middleware->handle($envelope, $stack),
         );
     }
 

--- a/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use stdClass;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\DoctrineFlushMiddleware;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
 use Symfony\Component\Messenger\Envelope;
@@ -66,7 +67,7 @@ class DoctrineFlushMiddlewareTest extends TestCase
 
     private function createEnvelope(): Envelope
     {
-        return new Envelope(new \stdClass());
+        return new Envelope(new stdClass());
     }
 
     private function createStack(): StackMiddleware

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
@@ -33,7 +33,7 @@ class LockMiddlewareTest extends TestCase
     {
         $this->lockFactory = $this->prophesize(LockFactory::class);
         $this->middleware = new LockMiddleware(
-            $this->lockFactory->reveal()
+            $this->lockFactory->reveal(),
         );
     }
 
@@ -47,7 +47,7 @@ class LockMiddlewareTest extends TestCase
 
         $this->assertSame(
             $envelope,
-            $this->middleware->handle($envelope, $stack)
+            $this->middleware->handle($envelope, $stack),
         );
     }
 
@@ -69,7 +69,7 @@ class LockMiddlewareTest extends TestCase
 
         $this->assertSame(
             $envelope,
-            $this->middleware->handle($envelope, $stack)
+            $this->middleware->handle($envelope, $stack),
         );
     }
 

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use stdClass;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockMiddleware;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockStamp;
 use Symfony\Component\Lock\LockFactory;
@@ -75,7 +76,7 @@ class LockMiddlewareTest extends TestCase
 
     private function createEnvelope(): Envelope
     {
-        return new Envelope(new \stdClass());
+        return new Envelope(new stdClass());
     }
 
     private function createStack(): StackMiddleware

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sulu\Messenger\Tests\Unit\Common\Infrastructure\Symfony\Messenger\LockMiddleware;
 
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Messenger\Tests\Unit\Common\Infrastructure\Symfony\Messenger\LockMiddleware;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockMiddleware;
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockStamp;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+
+/**
+ * @covers \Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockMiddleware
+ */
+class LockMiddlewareTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private LockMiddleware $middleware;
+
+    /**
+     * @var ObjectProphecy<LockFactory>
+     */
+    private ObjectProphecy $lockFactory;
+
+    protected function setUp(): void
+    {
+        $this->lockFactory = $this->prophesize(LockFactory::class);
+        $this->middleware = new LockMiddleware(
+            $this->lockFactory->reveal()
+        );
+    }
+
+    public function testHandleWithoutStamp(): void
+    {
+        $envelope = $this->createEnvelope();
+        $stack = $this->createStack();
+
+        $this->lockFactory->createLock(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->assertSame(
+            $envelope,
+            $this->middleware->handle($envelope, $stack)
+        );
+    }
+
+    public function testHandleWithStamp(): void
+    {
+        $envelope = $this->createEnvelope();
+        $envelope = $envelope->with(new LockStamp('test', 30, true));
+        $stack = $this->createStack();
+
+        $lock = $this->prophesize(LockInterface::class);
+        $lock->acquire(true)
+            ->shouldBeCalled();
+        $lock->release()
+            ->shouldBeCalled();
+
+        $this->lockFactory->createLock('test', 30, true)
+            ->willReturn($lock->reveal())
+            ->shouldBeCalled();
+
+        $this->assertSame(
+            $envelope,
+            $this->middleware->handle($envelope, $stack)
+        );
+    }
+
+    private function createEnvelope(): Envelope
+    {
+        return new Envelope(new \stdClass());
+    }
+
+    private function createStack(): StackMiddleware
+    {
+        return new StackMiddleware([]);
+    }
+}

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockStampTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockStampTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockStamp
+ */
+class LockStampTest extends TestCase
+{
+    public function testGetResource(): void
+    {
+        $model = $this->createInstance(['resource' => 'Resource']);
+        $this->assertSame('Resource', $model->getResource());
+    }
+
+    public function testGetTtl(): void
+    {
+        $model = $this->createInstance(['ttl' => 30.0]);
+        $this->assertSame(30.0, $model->getTtl());
+    }
+
+    public function testGetAutoRelease(): void
+    {
+        $model = $this->createInstance(['autoRelease' => true]);
+        $this->assertTrue($model->getAutoRelease());
+    }
+
+    /**
+     * @param array{
+     *    resource: string,
+     *    ttl: float|null,
+     *    autoRelease: bool,
+     * } $data
+     */
+    public function createInstance($data = []): LockStamp
+    {
+        return new LockStamp($data['resource'] ?? 'Resource', $data['ttl'] ?? 300.0, $data['autoRelease'] ?? true);
+    }
+}

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockStampTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockStampTest.php
@@ -31,12 +31,12 @@ class LockStampTest extends TestCase
 
     /**
      * @param array{
-     *    resource: string,
-     *    ttl: float|null,
-     *    autoRelease: bool,
+     *    resource?: string,
+     *    ttl?: float|null,
+     *    autoRelease?: bool,
      * } $data
      */
-    public function createInstance($data = []): LockStamp
+    public function createInstance(array $data = []): LockStamp
     {
         return new LockStamp($data['resource'] ?? 'Resource', $data['ttl'] ?? 300.0, $data['autoRelease'] ?? true);
     }

--- a/tests/Unit/Infrastructure/Symfony/Messenger/UnpackExceptionMiddleware/UnpackExceptionMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/UnpackExceptionMiddleware/UnpackExceptionMiddlewareTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Sulu\Messenger\Tests\Unit\Common\Infrastructure\Symfony\Messenger\UnpackExceptionMiddleware;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\UnpackExceptionMiddleware\UnpackExceptionMiddleware;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
@@ -37,12 +39,12 @@ class UnpackExceptionMiddlewareTest extends TestCase
 
     public function testHandleException(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Specific unpacked exception.');
 
         $envelope = $this->createEnvelope();
-        $stack = $this->createStack(function () use ($envelope) {
-            throw new HandlerFailedException($envelope, [new \LogicException('Specific unpacked exception.')]);
+        $stack = $this->createStack(function () use ($envelope): never {
+            throw new HandlerFailedException($envelope, [new LogicException('Specific unpacked exception.')]);
         });
 
         $this->assertSame(
@@ -53,7 +55,7 @@ class UnpackExceptionMiddlewareTest extends TestCase
 
     private function createEnvelope(): Envelope
     {
-        return new Envelope(new \stdClass());
+        return new Envelope(new stdClass());
     }
 
     private function createStack(callable $handler = null): StackMiddleware

--- a/tests/Unit/Infrastructure/Symfony/Messenger/UnpackExceptionMiddleware/UnpackExceptionMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/UnpackExceptionMiddleware/UnpackExceptionMiddlewareTest.php
@@ -31,7 +31,7 @@ class UnpackExceptionMiddlewareTest extends TestCase
 
         $this->assertSame(
             $envelope,
-            $this->middleware->handle($envelope, $stack)
+            $this->middleware->handle($envelope, $stack),
         );
     }
 
@@ -47,7 +47,7 @@ class UnpackExceptionMiddlewareTest extends TestCase
 
         $this->assertSame(
             $envelope,
-            $this->middleware->handle($envelope, $stack)
+            $this->middleware->handle($envelope, $stack),
         );
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,6 @@ use Symfony\Component\Dotenv\Dotenv;
 require \dirname(__DIR__) . '/vendor/autoload.php';
 (new Dotenv())->bootEnv(__DIR__ . '/Application/.env');
 
-if (\class_exists(\Locale::class)) {
-    \Locale::setDefault('en');
+if (\class_exists(Locale::class)) {
+    Locale::setDefault('en');
 }

--- a/tests/phpstan/object-manager.php
+++ b/tests/phpstan/object-manager.php
@@ -23,7 +23,7 @@ $objectManager = $container->get('doctrine')->getManager();
 // this is a workaround for the following phpstan issue: https://github.com/phpstan/phpstan-doctrine/issues/98
 $resolveTargetEntityListener = \current(\array_filter(
     $objectManager->getEventManager()->getListeners('loadClassMetadata'),
-    static fn ($listener) => $listener instanceof ResolveTargetEntityListener
+    static fn ($listener) => $listener instanceof ResolveTargetEntityListener,
 ));
 
 if ($resolveTargetEntityListener) {


### PR DESCRIPTION
The `LockMiddleware` will allow to lock specific resources by a given key. This is commonly
used to prevent concurrent access to the same resource and avoid race conditions.
The locking can be activated and controlled via the `LockStamp` which supports the same parameters
as the Symfony `LockFactory` to create the Lock.

```php
use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockStamp;

$this->handle(new Envelope(new YourMessage(), [new LockStamp('lock-key')]));

# set ttl and autorelease
$this->handle(new Envelope(new YourMessage(), [new LockStamp('lock-key', 300.0, true)]));

# multiple locks possible all locks need to be acquired before processing the message
$this->handle(new Envelope(new YourMessage(), [new LockStamp('lock-key-1'), new LockStamp('lock-key-2')]));
```