### PR TITLE
Make middleware services lazy via ServiceSubscriber

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,15 @@
         "doctrine/dbal": "^3.3",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.11",
+        "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/doctrine-bridge": "^5.4 || ^6.0",
         "symfony/framework-bundle": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
         "symfony/lock": "^5.4 || ^6.0",
-        "symfony/messenger": "^5.4 || ^6.0"
+        "symfony/messenger": "^5.4 || ^6.0",
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "coduo/php-matcher": "^6.0",

--- a/config/services.php
+++ b/config/services.php
@@ -13,12 +13,12 @@ return function (ContainerConfigurator $configurator) {
 
     $services->set('sulu_messenger.doctrine_flush_middleware')
         ->class(DoctrineFlushMiddleware::class)
-        ->args([service('doctrine.orm.entity_manager')]);
+        ->tag('container.service_subscriber');
 
     $services->set('sulu_messenger.unpack_exception_middleware')
         ->class(UnpackExceptionMiddleware::class);
 
     $services->set('sulu_messenger.lock_middleware')
         ->class(LockMiddleware::class)
-        ->args([service('lock.factory')]);
+        ->tag('container.service_subscriber');
 };

--- a/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
+++ b/src/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddleware.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
-class DoctrineFlushMiddleware implements MiddlewareInterface
+class DoctrineFlushMiddleware implements MiddlewareInterface, ServiceSubscriberInterface
 {
-    public function __construct(
-        private EntityManagerInterface $entityManager,
-    ) {
+    public function __construct(private ContainerInterface $container)
+    {
     }
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
@@ -22,9 +23,16 @@ class DoctrineFlushMiddleware implements MiddlewareInterface
 
         // flush unit-of-work to the database after the root message was handled successfully
         if (!empty($envelope->all(EnableFlushStamp::class))) {
-            $this->entityManager->flush();
+            $this->container->get('doctrine.orm.entity_manager')->flush();
         }
 
         return $envelope;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'doctrine.orm.entity_manager' => EntityManagerInterface::class,
+        ];
     }
 }

--- a/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
@@ -69,6 +69,16 @@ class DoctrineFlushMiddlewareTest extends TestCase
         );
     }
 
+    public function testGetSubscribedServices(): void
+    {
+        $this->assertSame(
+            [
+                'doctrine.orm.entity_manager' => EntityManagerInterface::class,
+            ],
+            $this->middleware->getSubscribedServices(),
+        );
+    }
+
     private function createEnvelope(): Envelope
     {
         return new Envelope(new stdClass());

--- a/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/FlushMiddleware/DoctrineFlushMiddlewareTest.php
@@ -11,6 +11,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\DoctrineFlushMiddleware;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackMiddleware;
 
@@ -31,8 +32,11 @@ class DoctrineFlushMiddlewareTest extends TestCase
     protected function setUp(): void
     {
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $container = new Container();
+        $container->set('doctrine.orm.entity_manager', $this->entityManager->reveal());
+
         $this->middleware = new DoctrineFlushMiddleware(
-            $this->entityManager->reveal(),
+            $container,
         );
     }
 

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
@@ -78,6 +78,16 @@ class LockMiddlewareTest extends TestCase
         );
     }
 
+    public function testGetSubscribedServices(): void
+    {
+        $this->assertSame(
+            [
+                'lock.factory' => LockFactory::class,
+            ],
+            $this->middleware->getSubscribedServices(),
+        );
+    }
+
     private function createEnvelope(): Envelope
     {
         return new Envelope(new stdClass());

--- a/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Messenger/LockMiddleware/LockMiddlewareTest.php
@@ -11,6 +11,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockMiddleware;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\LockMiddleware\LockStamp;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Messenger\Envelope;
@@ -33,8 +34,11 @@ class LockMiddlewareTest extends TestCase
     protected function setUp(): void
     {
         $this->lockFactory = $this->prophesize(LockFactory::class);
+        $container = new Container();
+        $container->set('lock.factory', $this->lockFactory->reveal());
+
         $this->middleware = new LockMiddleware(
-            $this->lockFactory->reveal(),
+            $container,
         );
     }
 


### PR DESCRIPTION
Middleware are always loaded. To avoid initialize heavy service like `EntityManager` for Messages which do not require it we can use `ServiceSubscriber` which will initialize the service only when it is used.

I currently did not found another way then `ServiceSubscriber` to make a service `lazy`. Symfony does not support that a service `argument` is lazy only a whole service.