### PR TITLE
Temporary use rector dev-main to fix rector CI error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^9.5",
         "qossmic/deptrac-shim": "^0.24.0 || ^1.0",
-        "rector/rector": "^1.0",
+        "rector/rector": "dev-main",
         "schranz/test-generator": "^0.4",
         "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
         "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",


### PR DESCRIPTION
while wait for new rector release, dev-main can be used.