### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -46,7 +46,6 @@ jobs:
                     - php-version: '8.4'
                       coverage: false
                       dependency-versions: 'highest'
-                      composer-options: '--ignore-platform-reqs'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "proprietary",
     "type": "sulu-bundle",
     "require": {
-        "php": "8.0.* || 8.1.* || 8.2.* || 8.3.*",
+        "php": "8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.11",


### PR DESCRIPTION
This allows installation on PHP 8.4. Linter will still run on 8.3 as php cs fixer not yet compatible with PHP 8.4