### PR TITLE
Allow doctrine 3 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "8.0.* || 8.1.* || 8.2.*",
         "doctrine/dbal": "^3.3",
         "doctrine/doctrine-bundle": "^2.5",
-        "doctrine/orm": "^2.11",
+        "doctrine/orm": "^2.11||^3.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "8.0.* || 8.1.* || 8.2.*",
         "doctrine/dbal": "^3.3",
         "doctrine/doctrine-bundle": "^2.5",
-        "doctrine/orm": "^2.11||^3.0",
+        "doctrine/orm": "^2.11 || ^3.0",
         "psr/container": "^1.0 || ^2.0",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",


### PR DESCRIPTION
We don't really use anything from the doctrine package except for the `EntityManagerInterface` which did not change.