### PR TITLE
Allow doctrine dbal 4 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "sulu-bundle",
     "require": {
         "php": "8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
-        "doctrine/dbal": "^2.13 || ^3.0 || ^4.0"
+        "doctrine/dbal": "^2.13 || ^3.0 || ^4.0",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.11 || ^3.0",
         "psr/container": "^1.0 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "sulu-bundle",
     "require": {
         "php": "8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
-        "doctrine/dbal": "^2.13 || ^3.0",
+        "doctrine/dbal": "^2.13 || ^3.0 || ^4.0"
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.11 || ^3.0",
         "psr/container": "^1.0 || ^2.0",


### PR DESCRIPTION
We only use the EntityManagerInterface in this package which is still the same.